### PR TITLE
Add Node microservice skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,22 @@ Opcionales:
 -Las gallinas fallecen pasados [] días. 
 
 -Las gallinas ponen [] huevos cada [] días. 
+
+## Microservices Architecture
+
+This repository now includes a minimal setup for a Node.js-based microservice architecture.
+The `services/` folder contains individual services:
+
+- `gateway-service`
+- `user-service`
+- `inventory-service`
+- `transaction-service`
+- `reporting-service`
+
+Each service exposes a simple HTTP endpoint and can be started together using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+This will launch all services on ports 3000-3004 respectively.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  gateway-service:
+    build: ./services/gateway-service
+    ports:
+      - "3000:3000"
+  user-service:
+    build: ./services/user-service
+    ports:
+      - "3001:3001"
+  inventory-service:
+    build: ./services/inventory-service
+    ports:
+      - "3002:3002"
+  transaction-service:
+    build: ./services/transaction-service
+    ports:
+      - "3003:3003"
+  reporting-service:
+    build: ./services/reporting-service
+    ports:
+      - "3004:3004"

--- a/services/gateway-service/.dockerignore
+++ b/services/gateway-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/services/gateway-service/Dockerfile
+++ b/services/gateway-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/services/gateway-service/index.js
+++ b/services/gateway-service/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ service: 'gateway-service' });
+});
+
+app.listen(PORT, () => {
+  console.log(`gateway-service listening on port ${PORT}`);
+});

--- a/services/gateway-service/package.json
+++ b/services/gateway-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "gateway-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/inventory-service/.dockerignore
+++ b/services/inventory-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/services/inventory-service/Dockerfile
+++ b/services/inventory-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/services/inventory-service/index.js
+++ b/services/inventory-service/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3002;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ service: 'inventory-service' });
+});
+
+app.listen(PORT, () => {
+  console.log(`inventory-service listening on port ${PORT}`);
+});

--- a/services/inventory-service/package.json
+++ b/services/inventory-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "inventory-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/reporting-service/.dockerignore
+++ b/services/reporting-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/services/reporting-service/Dockerfile
+++ b/services/reporting-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/services/reporting-service/index.js
+++ b/services/reporting-service/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3004;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ service: 'reporting-service' });
+});
+
+app.listen(PORT, () => {
+  console.log(`reporting-service listening on port ${PORT}`);
+});

--- a/services/reporting-service/package.json
+++ b/services/reporting-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "reporting-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/transaction-service/.dockerignore
+++ b/services/transaction-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/services/transaction-service/Dockerfile
+++ b/services/transaction-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/services/transaction-service/index.js
+++ b/services/transaction-service/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3003;
+
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ service: 'transaction-service' });
+});
+
+app.listen(PORT, () => {
+  console.log(`transaction-service listening on port ${PORT}`);
+});

--- a/services/transaction-service/package.json
+++ b/services/transaction-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "transaction-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/services/user-service/.dockerignore
+++ b/services/user-service/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/services/user-service/Dockerfile
+++ b/services/user-service/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+CMD ["npm", "start"]

--- a/services/user-service/index.js
+++ b/services/user-service/index.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.get('/users', (req, res) => {
+  res.json({ message: 'User service root' });
+});
+
+app.listen(PORT, () => {
+  console.log(`User service listening on port ${PORT}`);
+});

--- a/services/user-service/package.json
+++ b/services/user-service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "user-service",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add Node.js microservice skeletons under `services/`
- provide Dockerfile for each service and a compose file
- document the microservices in the README

## Testing
- `node -v`
- *(compose not available)*

------
https://chatgpt.com/codex/tasks/task_e_683fa152d7b8832cb0a11ac7b907f2dc