### PR TITLE
Add Flyway migration for extra article fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ mvn spring-boot:run
 ```
 
 Esto compilará el proyecto y levantará el servidor embebido de Spring Boot.
+
+### Actualización de la base de datos
+Si cuentas con una base de datos existente creada antes de esta versión,
+ejecuta la migración de Flyway `V1_0_2__add_article_fields.sql` para añadir las
+columnas `age`, `production` y `display_price` a la tabla `articles`.

--- a/src/main/resources/db/migration/V1_0_2__add_article_fields.sql
+++ b/src/main/resources/db/migration/V1_0_2__add_article_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE articles
+    ADD COLUMN age INT NOT NULL DEFAULT 0,
+    ADD COLUMN production VARCHAR(255),
+    ADD COLUMN display_price VARCHAR(255);


### PR DESCRIPTION
## Summary
- introduce `age`, `production` and `display_price` columns via new Flyway migration
- document migration requirement for existing databases

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9bdd94c832cb3bbad6e0a802b67