### PR TITLE
Fix report template rendering

### DIFF
--- a/src/main/java/com/chickentest/controller/FarmController.java
+++ b/src/main/java/com/chickentest/controller/FarmController.java
@@ -247,10 +247,12 @@ public class FarmController {
 
     @GetMapping("/report")
     @PreAuthorize("isAuthenticated()")
-    public String report(Model model) {
+    public String report(@AuthenticationPrincipal User user, Model model) {
         try {
             Report report = farmService.generateReport();
+            List<Movement> movements = farmService.getMovements(user);
             model.addAttribute("report", report);
+            model.addAttribute("movements", movements);
             return "movimientos-reporte";
         } catch (FarmException e) {
             model.addAttribute("error", e.getMessage());

--- a/src/main/resources/templates/movimientos-reporte.html
+++ b/src/main/resources/templates/movimientos-reporte.html
@@ -18,11 +18,11 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr th:each="movimiento : ${report.movimientos}">
-                                    <td th:text="${movimiento.tipo}"></td>
-                                    <td th:text="${movimiento.articulo.nombre}"></td>
-                                    <td th:text="${movimiento.cantidad}"></td>
-                                    <td th:text="${#temporals.format(movimiento.fecha, 'dd/MM/yyyy HH:mm')}"></td>
+                                <tr th:each="movement : ${movements}">
+                                    <td th:text="${movement.type}"></td>
+                                    <td th:text="${movement.article.name}"></td>
+                                    <td th:text="${movement.units}"></td>
+                                    <td th:text="${#temporals.format(movement.date, 'dd/MM/yyyy HH:mm')}"></td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
## Summary
- inject `movements` list when loading `/report`
- iterate over the new `movements` attribute in the report template

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9c24e68832cb5bd448ba19e645d