### PR TITLE
Implement egg hatching scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/src/main/java/com/chickentest/ChickenTestApplication.java
+++ b/src/main/java/com/chickentest/ChickenTestApplication.java
@@ -4,8 +4,10 @@ package com.chickentest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ChickenTestApplication {
     public static void main(String[] args) {
         SpringApplication.run(ChickenTestApplication.class, args);

--- a/src/main/java/com/chickentest/config/Constants.java
+++ b/src/main/java/com/chickentest/config/Constants.java
@@ -1,6 +1,7 @@
 package com.chickentest.config;
 
 public class Constants {
+    public static final int EGG_HATCH_DAYS = 3;
     public static class Category {
         public static final String CHICKENS = "Chickens";
         public static final String EGGS = "Eggs";

--- a/src/main/java/com/chickentest/repository/ArticleRepository.java
+++ b/src/main/java/com/chickentest/repository/ArticleRepository.java
@@ -12,4 +12,8 @@ import com.chickentest.domain.Category;
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     @Query("SELECT COALESCE(SUM(units), 0) FROM Article WHERE category = :category")
     int findTotalUnitsByCategory(@Param("category") Category category);
+
+    java.util.List<Article> findByCategory(Category category);
+
+    java.util.Optional<Article> findByNameAndCategory(String name, Category category);
 }

--- a/src/main/java/com/chickentest/scheduler/EggHatchScheduler.java
+++ b/src/main/java/com/chickentest/scheduler/EggHatchScheduler.java
@@ -1,0 +1,22 @@
+package com.chickentest.scheduler;
+
+import com.chickentest.service.FarmService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class EggHatchScheduler {
+
+    private final FarmService farmService;
+
+    public EggHatchScheduler(FarmService farmService) {
+        this.farmService = farmService;
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void hatchEggsJob() {
+        farmService.hatchEggs();
+    }
+}

--- a/src/test/java/com/chickentest/service/FarmServiceSchedulingTest.java
+++ b/src/test/java/com/chickentest/service/FarmServiceSchedulingTest.java
@@ -1,0 +1,76 @@
+package com.chickentest.service;
+
+import com.chickentest.config.Constants;
+import com.chickentest.domain.Article;
+import com.chickentest.domain.Category;
+import com.chickentest.domain.Movement;
+import com.chickentest.domain.MovementType;
+import com.chickentest.repository.ArticleRepository;
+import com.chickentest.repository.CategoryRepository;
+import com.chickentest.repository.MovementRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class FarmServiceSchedulingTest {
+
+    @Autowired
+    private FarmService farmService;
+    @Autowired
+    private ArticleRepository articleRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private MovementRepository movementRepository;
+
+    private Category eggs;
+    private Category chickens;
+
+    @BeforeEach
+    void setup() {
+        eggs = categoryRepository.findByDisplayName(Constants.Category.EGGS);
+        chickens = categoryRepository.findByDisplayName(Constants.Category.CHICKENS);
+        articleRepository.deleteAll();
+        movementRepository.deleteAll();
+        Article egg = new Article();
+        egg.setName("Batch A");
+        egg.setCategory(eggs);
+        egg.setUnits(10);
+        egg.setPrice(1.0);
+        egg.setAge(Constants.EGG_HATCH_DAYS - 1);
+        egg.setProduction("test");
+        egg.setCreation(new Date());
+        articleRepository.save(egg);
+    }
+
+    @Test
+    void testHatchEggs() {
+        farmService.hatchEggs();
+
+        List<Article> eggList = articleRepository.findByCategory(eggs);
+        assertEquals(1, eggList.size());
+        Article egg = eggList.get(0);
+        assertEquals(0, egg.getUnits());
+        assertEquals(0, egg.getAge());
+
+        List<Article> chickenList = articleRepository.findByCategory(chickens);
+        assertEquals(1, chickenList.size());
+        Article chicken = chickenList.get(0);
+        assertEquals(10, chicken.getUnits());
+
+        List<Movement> movements = movementRepository.findAll();
+        assertEquals(1, movements.size());
+        Movement m = movements.get(0);
+        assertEquals(MovementType.PRODUCTION, m.getType());
+        assertEquals(10, m.getUnits());
+    }
+}


### PR DESCRIPTION
## Summary
- add `EGG_HATCH_DAYS` constant
- support searching articles by category/name
- schedule and implement egg hatching logic
- enable scheduling in Spring Boot app
- add test for egg hatching
- remove unused test application properties
- extract scheduled job into dedicated class

## Testing
- `mvn -q test` *(fails: Could not download spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6861b9b8c0b4832c8f83602a9a9fd190