### PR TITLE
Add CSRF tokens to auth forms

### DIFF
--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -25,6 +25,7 @@
         <div class="login-form">
             <h2>Login 🐣</h2>
             <form th:action="@{/auth/login}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="form-group">
                     <label for="username">Username:</label>
                     <input type="text" id="username" name="username" required />

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -15,6 +15,7 @@
         <div class="register-form">
             <h2>Register 🐣</h2>
             <form th:action="@{/auth/register}" th:object="${user}" method="post">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                 <div class="form-group">
                     <label for="username">Username:</label>
                     <input type="text" id="username" th:field="*{username}" required />


### PR DESCRIPTION
## Summary
- fix login page by adding CSRF token field
- fix register page by adding CSRF token field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6861f301c5dc832c92ffc5ea58509aaf